### PR TITLE
Use cell width for image width to make terminal output predictable

### DIFF
--- a/src/Sixel/SixelCmdlet.cs
+++ b/src/Sixel/SixelCmdlet.cs
@@ -1,6 +1,5 @@
-using System.IO;
 using System.Management.Automation;
-using System.Net.Http;
+using Sixel.Terminal;
 
 namespace Sixel;
 
@@ -10,6 +9,7 @@ namespace Sixel;
 public sealed class ConvertSixelCmdlet : PSCmdlet
 {
   [Parameter(
+        HelpMessage = "A path to a local image to convert to sixel.",
         Mandatory = true,
         ValueFromPipelineByPropertyName = true,
         Position = 0,
@@ -20,6 +20,7 @@ public sealed class ConvertSixelCmdlet : PSCmdlet
   public string Path { get; set; } = null!;
 
   [Parameter(
+        HelpMessage = "A URL of the image to download and convert to sixel.",
         Mandatory = true,
         ValueFromPipeline = true,
         ParameterSetName = "Url"
@@ -27,18 +28,24 @@ public sealed class ConvertSixelCmdlet : PSCmdlet
   [Alias("Uri")]
   public string Url { get; set; } = null!;
 
-  [Parameter()]
+  [Parameter(
+        HelpMessage = "The maximum number of colors to use in the image."
+  )]
   [ValidateRange(1, 256)]
   public int MaxColors { get; set; } = 256;
 
-  [Parameter()]
+  [Parameter(
+        HelpMessage = "Width of the image in character cells, the height will be scaled to maintain aspect ratio."
+  )]
   public int Width { get; set; }
 
-  [Parameter()]
+  [Parameter(
+        HelpMessage = "Force the command to attempt to output sixel data even if the terminal does not support sixel."
+  )]
   public SwitchParameter Force { get; set; }
   protected override void BeginProcessing()
   {
-    if (Convert.GetTerminalSupportsSixel() == false && Force == false)
+    if (Compatibility.TerminalSupportsSixel() == false && Force == false)
     {
       this.ThrowTerminatingError(new ErrorRecord(new System.Exception("Terminal does not support sixel, override with -Force for test."), "SixelError", ErrorCategory.NotImplemented, null));
     }

--- a/src/Sixel/Terminal/Compatibility.cs
+++ b/src/Sixel/Terminal/Compatibility.cs
@@ -1,0 +1,93 @@
+using Sixel.Terminal.Models;
+
+namespace Sixel.Terminal;
+
+public class Compatibility
+{
+  /// <summary>
+  /// Memory-caches the result of the terminal supporting sixel graphics.
+  /// </summary>
+  private static bool? _terminalSupportsSixel;
+
+  /// <summary>
+  /// Memory-caches the result of the terminal cell size.
+  /// </summary>
+  private static CellSize? _cellSize;
+
+  /// <summary>
+  /// Get the cell size of the terminal in pixel-sixel size.
+  /// The response to the command will look like [6;20;10t where the 20 is height and 10 is width.
+  /// I think the 6 is the terminal class, which is not used here.
+  /// </summary>
+  /// <returns>The number of pixel sixels that will fit in a single character cell.</returns>
+  public static CellSize GetCellSize()
+  {
+    if (_cellSize != null)
+    {
+      return _cellSize;
+    }
+
+    var response = GetControlSequenceResponse("[16t");
+
+    try
+    {
+      var parts = response.Split(';', 't');
+      _cellSize = new CellSize {
+        PixelWidth = int.Parse(parts[2]),
+        PixelHeight = int.Parse(parts[1])
+      };
+    }
+    catch
+    {
+      // Return the default Windows Terminal size if we can't get the size from the terminal.
+      _cellSize = new CellSize {
+        PixelWidth = 10,
+        PixelHeight = 20
+      };
+      // TODO: Write this to a normal powershell warning stream.
+      Console.Error.WriteLine("Could not get terminal cell size, using default size 10x20.");
+    }
+
+    return _cellSize;
+  }
+
+  /// <summary>
+  /// Check if the terminal supports sixel graphics.
+  /// This is done by sending the terminal a Device Attributes request.
+  /// If the terminal responds with a response that contains ";4;" then it supports sixel graphics.
+  /// https://vt100.net/docs/vt510-rm/DA1.html
+  /// </summary>
+  /// <returns>True if the terminal supports sixel graphics, false otherwise.</returns>
+  public static bool TerminalSupportsSixel()
+  {
+    if (_terminalSupportsSixel.HasValue)
+    {
+      return _terminalSupportsSixel.Value;
+    }
+
+    _terminalSupportsSixel = GetControlSequenceResponse("[c").Contains(";4;");
+    
+    return _terminalSupportsSixel.Value;
+  }
+
+  /// <summary>
+  /// Send a control sequence to the terminal and read back the response from STDIN.
+  /// </summary>
+  /// <param name="controlSequence"></param>
+  /// <returns>The response from the terminal.</returns>
+  private static string GetControlSequenceResponse(string controlSequence)
+  {
+    char? c;
+    var response = string.Empty;
+    
+    Console.Write($"{Constants.Escape}{controlSequence}");
+    do
+    {
+      c = Console.ReadKey(true).KeyChar;
+      response += c;
+    } while (c != 'c' && Console.KeyAvailable);
+
+    return response;
+  }
+
+}

--- a/src/Sixel/Terminal/Constants.cs
+++ b/src/Sixel/Terminal/Constants.cs
@@ -1,0 +1,9 @@
+namespace Sixel.Terminal;
+
+public static class Constants
+{
+    /// <summary>
+    /// The character to use when entering a terminal escape code sequence.
+    /// </summary>
+    public const string Escape = "\u001b";
+}

--- a/src/Sixel/Terminal/Models/CellSize.cs
+++ b/src/Sixel/Terminal/Models/CellSize.cs
@@ -1,0 +1,15 @@
+namespace Sixel.Terminal.Models;
+
+public class CellSize
+{
+  /// <summary>
+  /// The width of a cell in pixels.
+  /// </summary>
+  public int PixelWidth { get; set; }
+
+  /// <summary>
+  /// The height of a cell in pixels.
+  /// This isn't used for anything yet but this would be required for something like spectre console that needs to work around the size of the rendered sixel image.
+  /// </summary>
+  public int PixelHeight { get; set; }
+}


### PR DESCRIPTION
I'm not sure how you feel about the scaling but for spectre console the cell width will need to be used to scale the image to make it fit within other rendered stuff on the screen. IMO using cell width / height to scale the image makes it more predictable and easier to intergrate sixel images into other terminal applications. Or it could accept a PixelWidth and CellWidth parameter 🤷 

![image](https://github.com/user-attachments/assets/405d0363-4060-4a96-9bd0-ea990913a9d8)

This only scales width based on the terminals reported cell size, the height isn't really exposed but it could be calculated.