### PR TITLE
Fix for TerminalSupportsSixel()

### DIFF
--- a/src/Sixel/Terminal/Compatibility.cs
+++ b/src/Sixel/Terminal/Compatibility.cs
@@ -160,7 +160,10 @@ public static class Compatibility
     {
       return _terminalSupportsSixel.Value;
     }
-    _terminalSupportsSixel = GetControlSequenceResponse("[c").Contains(";4;");
+
+    var response = GetControlSequenceResponse("[c");
+    _terminalSupportsSixel = response.Contains(";4;") || response.Contains(";4c");
+
     return _terminalSupportsSixel.Value;
   }
 


### PR DESCRIPTION
"4" could be last parameter in the DA response; affects support for Konsole.

Note I stole this code for https://github.com/teramako/SixPix.NET and @j4james caught this issue.